### PR TITLE
AddNewFiducialNode no more in mlogic scope

### DIFF
--- a/ContactPositionEstimator/ContactPositionEstimator.py
+++ b/ContactPositionEstimator/ContactPositionEstimator.py
@@ -444,7 +444,7 @@ class ContactPositionEstimatorLogic(ScriptedLoadableModuleLogic):
         mlogic.SetDefaultMarkupsDisplayNodeColor(0.39, 0.78, 0.78)  # AZZURRO
         mlogic.SetDefaultMarkupsDisplayNodeSelectedColor(0.39, 1.0, 0.39)  # VERDONE
 
-        fidNode = slicer.util.getNode(mlogic.AddNewFiducialNode("recon"))
+        fidNode = slicer.util.getNode(slicer.modules.markups.logic().AddNewFiducialNode("recon"))
 
         # Save the volume as has been modified
         self.tmpVolumeFile = parentPath + "/Tmp/tmp.nii.gz"


### PR DESCRIPTION
The previous update, changed the value of `mlogic` that now is `mlogic = slicer.modules.markups.logic().GetDefaultMarkupsDisplayNode()`
to access `AddNewFiducialNode()` we need to use the `slicer.modules.markups.logic()`, but mlogic isnt that anymore, so instead of mlogic i use the whole `slicer.modules.markups.logic()`