### PR TITLE
mlogic changed scope

### DIFF
--- a/ContactPositionEstimator/ContactPositionEstimator.py
+++ b/ContactPositionEstimator/ContactPositionEstimator.py
@@ -514,7 +514,7 @@ class ContactPositionEstimatorLogic(ScriptedLoadableModuleLogic):
                 slicer.mrmlScene.AddNode(model)
 
             # Lock all markup
-            mlogic.SetAllMarkupsLocked(fidNode, True)
+            slicer.modules.markups.logic().SetAllMarkupsLocked(fidNode, True)
 
             # update progress bar
             self.pb.setValue(i + 1)


### PR DESCRIPTION
in previous pull request, mlogic changed into slicer.modules.markups.logic().GetDefaultMarkupsDisplayNode() while the function that we want to  call is still inside slicer.modules.markups.logic()